### PR TITLE
Await SSH tunnel init using docker exec

### DIFF
--- a/docker_push_ssh/cli.py
+++ b/docker_push_ssh/cli.py
@@ -38,12 +38,17 @@ def waitForSshTunnelInit(retries=20, delay=1.0):
     for _ in range(retries):
         time.sleep(delay)
 
-        try:
-            response = urllib2.urlopen("http://localhost:5000/v2/", timeout=5)
-        except (socket.error, urllib2.URLError, httplib.BadStatusLine):
-            continue
+        sshCheckCommandResult = Command("docker", [
+            "exec",
+            "docker-push-ssh-tunnel",
+            "wget",
+            "-O", "/dev/null",
+            "-q",
+            "--timeout=5",
+            "http://localhost:5000/v2"
+        ]).environment_dict(os.environ).execute()
 
-        if response.getcode() == 200:
+        if not sshCheckCommandResult.failed():
             return True
 
     return False


### PR DESCRIPTION
This change is copied from #10 which was never finished. It adds a 5-second timeout to the wget command as requested over there. I'm not sure why this change is necessary but it is necessary for my setup on macOS 12.

Before this change:
```
% docker-push-ssh -i ~/.ssh/id_ed25519 me@some.server.net vidjo:latest
[REQUIRED] Ensure localhost:5000 is added to your insecure registries.
Setting up secure private registry... 
Establishing SSH Tunnel...
Waiting for SSH Tunnel Initialization...
ERROR
SSH Tunnel failed to initialize.
('', "Warning: Permanently added 'some.server.net,1.2.3.4' (ECDSA) to the list of known hosts.\r\n")
Cleaning up...
```

and after:
```
% docker-push-ssh -i ~/.ssh/id_ed25519 me@some.server.net vidjo:latest
[REQUIRED] Ensure localhost:5000 is added to your insecure registries.
Setting up secure private registry... 
Establishing SSH Tunnel...
Waiting for SSH Tunnel Initialization...
Priming Registry with base images...
Tagging image(s) for push...
Pushing Image(s) from local host...
Pushed Image vidjo:latest Successfully...
Pulling and Retagging Image on remote host...
Pulled Image vidjo:latest Successfully...
Cleaning up...
```